### PR TITLE
Type error & fixing PackageCompiler version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -70,6 +70,7 @@ fi
 # all code executed in this file will be precompiled
 if [[ -f warmup.jl ]]; then
   # ! means that it is allowed to fail
+  ! julia -e "import Pkg; Pkg.activate(\".\"); Pkg.instantiate()"
   ! julia --project=$(pwd) --trace-compile="precompile.jl" warmup.jl
   ! wc -l precompile.jl
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -18,14 +18,11 @@ cd ${BUILD_DIR}
 
 mkdir -p .profile.d
 
-DEFAULT_JULIA_VERSION=1.4.1
+DEFAULT_JULIA_VERSION=1.4.2
 JULIA_VERSION="$DEFAULT_JULIA_VERSION"
 if [[ -f Project.toml ]]; then
-  curl -Lo /tmp/faq https://github.com/jzelinskie/faq/releases/download/0.0.6/faq-linux-amd64
-  chmod +x /tmp/faq
-
-  JULIA_VERSION="$(/tmp/faq -Mr '.compat.julia' Project.toml -o json)"
-  [[ "$JULIA_VERSION" == "null" ]] && JULIA_VERSION="$DEFAULT_JULIA_VERSION"
+  JULIA_VERSION="$(sed -rn 's/^julia\s*=\s*"(.*)"/\1/p' Project.toml)"
+  [[ "$JULIA_VERSION" == "" ]] && JULIA_VERSION="$DEFAULT_JULIA_VERSION"
 fi
 
 JULIA_MAJOR_VERSION="$(echo "$JULIA_VERSION" | awk '{split($0,a,"."); print a[1]}')"

--- a/bin/compile
+++ b/bin/compile
@@ -13,6 +13,19 @@ set-env() {
 # parse args
 BUILD_DIR=$1
 CACHE_DIR=$2
+ENV_DIR=$3
+
+ls $ENV_DIR
+
+acceptlist_regex=${2:-''}
+denylist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
+if [ -d "$ENV_DIR" ]; then
+  for e in $(ls $ENV_DIR); do
+    echo "$e" | grep -E "$acceptlist_regex" | grep -qvE "$denylist_regex" &&
+    export "$e=$(cat $ENV_DIR/$e)"
+    :
+  done
+fi
 
 cd ${BUILD_DIR}
 

--- a/bin/compile
+++ b/bin/compile
@@ -66,6 +66,14 @@ if [ "${PIPESTATUS[*]}" != "0" ]; then
   exit 1
 fi
 
+# if there is a warmup.jl file, we run it to populate precompile.jl
+# all code executed in this file will be precompiled
+if [[ -f warmup.jl ]]; then
+  # ! means that it is allowed to fail
+  ! julia --project=$(pwd) --trace-compile="precompile.jl" warmup.jl
+  ! wc -l precompile.jl
+fi
+
 # these are not presistent in heroku
 mkdir -p ~/.julia/config
 set +H

--- a/bin/compile
+++ b/bin/compile
@@ -22,7 +22,7 @@ cd ${BUILD_DIR}
 
 mkdir -p .profile.d
 
-DEFAULT_JULIA_VERSION=1.6.0-rc1
+DEFAULT_JULIA_VERSION=1.7.0-rc1
 JULIA_VERSION="$DEFAULT_JULIA_VERSION"
 if [[ -f Project.toml ]]; then
   JULIA_VERSION="$(sed -rn 's/^julia\s*=\s*"(.*)"/\1/p' Project.toml)"

--- a/bin/compile
+++ b/bin/compile
@@ -72,13 +72,20 @@ fi
 mkdir -p ~/.julia/config
 set +H
 
+if [[ -f "$ENV_DIR/HEROKU_JULIA_PROJECT" ]]; then
+JULIA_PROJECT=`cat $ENV_DIR/HEROKU_JULIA_PROJECT`
+else
+JULIA_PROJECT=$(pwd)
+fi
+
+# ! means that it is allowed to fail
+! julia -e "import Pkg; Pkg.instantiate(); Pkg.API.precompile();"
+
 # if there is a warmup.jl file, we run it to populate precompile.jl
 # all code executed in this file will be precompiled
 if [[ -f warmup.jl ]]; then
   echo "== warmup start =="
-  # ! means that it is allowed to fail
-  ! julia -e "import Pkg; Pkg.activate(\".\"); Pkg.instantiate(); Pkg.API.precompile();"
-  ! julia --project=$(pwd) --trace-compile="precompile.jl" warmup.jl
+  ! julia --trace-compile="precompile.jl" warmup.jl
   echo "== warmup done =="
   ! wc -l precompile.jl
   echo ""
@@ -89,9 +96,10 @@ if [[ -f "$ENV_DIR/HEROKU_JULIA_SKIP_SYSIMAGE" ]]; then
 else
 julia <<__EOF__
 import Pkg
+Pkg.activate(mktempdir())
 Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.2.4"))
 using PackageCompiler
-Pkg.activate(".")
+Pkg.activate(get(ENV, "JULIA_PROJECT", "."))
 Pkg.instantiate()
 Pkg.API.precompile()
 proj = Pkg.API.project()

--- a/bin/compile
+++ b/bin/compile
@@ -87,18 +87,18 @@ fi
 if [[ -f "$ENV_DIR/HEROKU_JULIA_SKIP_SYSIMAGE" ]]; then
   echo "Skipping sysimage"
 else
-  julia <<__EOF__
-  import Pkg
-  Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.2.4"))
-  using PackageCompiler
-  Pkg.activate(".")
-  Pkg.instantiate()
-  Pkg.API.precompile()
-  proj = Pkg.API.project()
-  pkgs = Symbol.(keys(proj.dependencies))
-  proj.ispackage && push!(pkgs, Symbol(proj.name))
-  create_sysimage(pkgs, precompile_statements_file=isfile("precompile.jl") ? "precompile.jl" : String[], replace_default=true)
-  __EOF__
+julia <<__EOF__
+import Pkg
+Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.2.4"))
+using PackageCompiler
+Pkg.activate(".")
+Pkg.instantiate()
+Pkg.API.precompile()
+proj = Pkg.API.project()
+pkgs = Symbol.(keys(proj.dependencies))
+proj.ispackage && push!(pkgs, Symbol(proj.name))
+create_sysimage(pkgs, precompile_statements_file=isfile("precompile.jl") ? "precompile.jl" : String[], replace_default=true)
+__EOF__
 fi
 
 cp -r ~/.julia ${BUILD_DIR}/.julia

--- a/bin/compile
+++ b/bin/compile
@@ -76,7 +76,7 @@ set +H
 if [[ -f warmup.jl ]]; then
   echo "== warmup start =="
   # ! means that it is allowed to fail
-  ! julia -e "import Pkg; Pkg.activate(\".\"); Pkg.instantiate()"
+  ! julia -e "import Pkg; Pkg.activate(\".\"); Pkg.instantiate(); Pkg.API.precompile();"
   ! julia --project=$(pwd) --trace-compile="precompile.jl" warmup.jl
   echo "== warmup done =="
   ! wc -l precompile.jl
@@ -85,10 +85,11 @@ fi
 
 julia <<__EOF__
 import Pkg
-Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.1.1"))
+Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.2.1"))
 using PackageCompiler
 Pkg.activate(".")
 Pkg.instantiate()
+Pkg.API.precompile()
 proj = Pkg.API.project()
 pkgs = Symbol.(keys(proj.dependencies))
 proj.ispackage && push!(pkgs, Symbol(proj.name))

--- a/bin/compile
+++ b/bin/compile
@@ -18,7 +18,7 @@ cd ${BUILD_DIR}
 
 mkdir -p .profile.d
 
-DEFAULT_JULIA_VERSION=1.5.2
+DEFAULT_JULIA_VERSION=1.5.3
 JULIA_VERSION="$DEFAULT_JULIA_VERSION"
 if [[ -f Project.toml ]]; then
   JULIA_VERSION="$(sed -rn 's/^julia\s*=\s*"(.*)"/\1/p' Project.toml)"
@@ -82,7 +82,7 @@ fi
 
 julia <<__EOF__
 import Pkg
-Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.2.1"))
+Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.2.4"))
 using PackageCompiler
 Pkg.activate(".")
 Pkg.instantiate()

--- a/bin/compile
+++ b/bin/compile
@@ -15,17 +15,8 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
+echo "ENV variables:"
 ls $ENV_DIR
-
-acceptlist_regex=${2:-''}
-denylist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
-if [ -d "$ENV_DIR" ]; then
-  for e in $(ls $ENV_DIR); do
-    echo "$e" | grep -E "$acceptlist_regex" | grep -qvE "$denylist_regex" &&
-    export "$e=$(cat $ENV_DIR/$e)"
-    :
-  done
-fi
 
 cd ${BUILD_DIR}
 

--- a/bin/compile
+++ b/bin/compile
@@ -72,7 +72,7 @@ set +H
 
 julia <<__EOF__
 import Pkg
-Pkg.add(PackageSpec(name="PackageCompiler", version="1.1.1"))
+Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.1.1"))
 using PackageCompiler
 Pkg.activate(".")
 Pkg.instantiate()

--- a/bin/compile
+++ b/bin/compile
@@ -73,9 +73,9 @@ mkdir -p ~/.julia/config
 set +H
 
 if [[ -f "$ENV_DIR/HEROKU_JULIA_PROJECT" ]]; then
-JULIA_PROJECT=`cat $ENV_DIR/HEROKU_JULIA_PROJECT`
+  export JULIA_PROJECT=`cat $ENV_DIR/HEROKU_JULIA_PROJECT`
 else
-JULIA_PROJECT=$(pwd)
+  export JULIA_PROJECT=$(pwd)
 fi
 
 # ! means that it is allowed to fail

--- a/bin/compile
+++ b/bin/compile
@@ -18,7 +18,7 @@ cd ${BUILD_DIR}
 
 mkdir -p .profile.d
 
-DEFAULT_JULIA_VERSION=1.5.3
+DEFAULT_JULIA_VERSION=1.6.0-rc1
 JULIA_VERSION="$DEFAULT_JULIA_VERSION"
 if [[ -f Project.toml ]]; then
   JULIA_VERSION="$(sed -rn 's/^julia\s*=\s*"(.*)"/\1/p' Project.toml)"
@@ -80,6 +80,7 @@ if [[ -f warmup.jl ]]; then
   echo ""
 fi
 
+if [[ -z "${HEROKU_JULIA_SKIP_SYSIMAGE}" ]]; then
 julia <<__EOF__
 import Pkg
 Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.2.4"))
@@ -92,6 +93,7 @@ pkgs = Symbol.(keys(proj.dependencies))
 proj.ispackage && push!(pkgs, Symbol(proj.name))
 create_sysimage(pkgs, precompile_statements_file=isfile("precompile.jl") ? "precompile.jl" : String[], replace_default=true)
 __EOF__
+fi
 
 cp -r ~/.julia ${BUILD_DIR}/.julia
 rm -rf ${BUILD_DIR}/.julia/registries

--- a/bin/compile
+++ b/bin/compile
@@ -93,19 +93,21 @@ if [[ -f warmup.jl ]]; then
   echo ""
 fi
 
-if [[ -z "${HEROKU_JULIA_SKIP_SYSIMAGE}" ]]; then
-julia <<__EOF__
-import Pkg
-Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.2.4"))
-using PackageCompiler
-Pkg.activate(".")
-Pkg.instantiate()
-Pkg.API.precompile()
-proj = Pkg.API.project()
-pkgs = Symbol.(keys(proj.dependencies))
-proj.ispackage && push!(pkgs, Symbol(proj.name))
-create_sysimage(pkgs, precompile_statements_file=isfile("precompile.jl") ? "precompile.jl" : String[], replace_default=true)
-__EOF__
+if [[ -f "$ENV_DIR/HEROKU_JULIA_SKIP_SYSIMAGE" ]]; then
+  echo "Skipping sysimage"
+else
+  julia <<__EOF__
+  import Pkg
+  Pkg.add(Pkg.PackageSpec(name="PackageCompiler", version="1.2.4"))
+  using PackageCompiler
+  Pkg.activate(".")
+  Pkg.instantiate()
+  Pkg.API.precompile()
+  proj = Pkg.API.project()
+  pkgs = Symbol.(keys(proj.dependencies))
+  proj.ispackage && push!(pkgs, Symbol(proj.name))
+  create_sysimage(pkgs, precompile_statements_file=isfile("precompile.jl") ? "precompile.jl" : String[], replace_default=true)
+  __EOF__
 fi
 
 cp -r ~/.julia ${BUILD_DIR}/.julia

--- a/bin/compile
+++ b/bin/compile
@@ -57,27 +57,31 @@ export JULIA_LOAD_PATH="@:"
 echo $PATH
 echo $LD_LIBRARY_PATH
 echo $(cmake -version)
-echo $(julia -v)
 
-echo " done"
+echo "== julia installed =="
+echo $(julia -v)
+echo ""
 
 if [ "${PIPESTATUS[*]}" != "0" ]; then
   echo " !     Failed to install ${JULIA_DIST}"
   exit 1
 fi
 
-# if there is a warmup.jl file, we run it to populate precompile.jl
-# all code executed in this file will be precompiled
-if [[ -f warmup.jl ]]; then
-  # ! means that it is allowed to fail
-  ! julia -e "import Pkg; Pkg.activate(\".\"); Pkg.instantiate()"
-  ! julia --project=$(pwd) --trace-compile="precompile.jl" warmup.jl
-  ! wc -l precompile.jl
-fi
-
 # these are not presistent in heroku
 mkdir -p ~/.julia/config
 set +H
+
+# if there is a warmup.jl file, we run it to populate precompile.jl
+# all code executed in this file will be precompiled
+if [[ -f warmup.jl ]]; then
+  echo "== warmup start =="
+  # ! means that it is allowed to fail
+  ! julia -e "import Pkg; Pkg.activate(\".\"); Pkg.instantiate()"
+  ! julia --project=$(pwd) --trace-compile="precompile.jl" warmup.jl
+  echo "== warmup done =="
+  ! wc -l precompile.jl
+  echo ""
+fi
 
 julia <<__EOF__
 import Pkg

--- a/bin/compile
+++ b/bin/compile
@@ -72,14 +72,14 @@ set +H
 
 julia <<__EOF__
 import Pkg
-Pkg.add("PackageCompiler")
+Pkg.add(PackageSpec(name="PackageCompiler", version="1.1.1"))
 using PackageCompiler
 Pkg.activate(".")
 Pkg.instantiate()
 proj = Pkg.API.project()
 pkgs = Symbol.(keys(proj.dependencies))
 proj.ispackage && push!(pkgs, Symbol(proj.name))
-create_sysimage(pkgs, precompile_statements_file=isfile("precompile.jl") ? "precompile.jl" : nothing, replace_default=true)
+create_sysimage(pkgs, precompile_statements_file=isfile("precompile.jl") ? "precompile.jl" : String[], replace_default=true)
 __EOF__
 
 cp -r ~/.julia ${BUILD_DIR}/.julia

--- a/bin/compile
+++ b/bin/compile
@@ -93,6 +93,8 @@ fi
 
 if [[ -f "$ENV_DIR/HEROKU_JULIA_SKIP_SYSIMAGE" ]]; then
   echo "Skipping sysimage"
+  # let's import all the required packages
+  ! julia -e "import Pkg; eval(Expr(:using, (Expr(:(.), Symbol(n)) for n in keys(Pkg.API.project().dependencies))...))"
 else
 julia <<__EOF__
 import Pkg

--- a/bin/compile
+++ b/bin/compile
@@ -18,7 +18,7 @@ cd ${BUILD_DIR}
 
 mkdir -p .profile.d
 
-DEFAULT_JULIA_VERSION=1.4.2
+DEFAULT_JULIA_VERSION=1.5.2
 JULIA_VERSION="$DEFAULT_JULIA_VERSION"
 if [[ -f Project.toml ]]; then
   JULIA_VERSION="$(sed -rn 's/^julia\s*=\s*"(.*)"/\1/p' Project.toml)"

--- a/bin/compile
+++ b/bin/compile
@@ -22,7 +22,7 @@ cd ${BUILD_DIR}
 
 mkdir -p .profile.d
 
-DEFAULT_JULIA_VERSION=1.7.0-rc1
+DEFAULT_JULIA_VERSION=1.7.2
 JULIA_VERSION="$DEFAULT_JULIA_VERSION"
 if [[ -f Project.toml ]]; then
   JULIA_VERSION="$(sed -rn 's/^julia\s*=\s*"(.*)"/\1/p' Project.toml)"

--- a/bin/compile
+++ b/bin/compile
@@ -48,7 +48,7 @@ done
 set-env PATH '$HOME/.apt/usr/bin:$HOME/julia/bin:$PATH'
 set-env LIBRARY_PATH '$HOME/.apt/usr/lib/x86_64-linux-gnu:$HOME/julia/lib:$HOME/julia/lib/x86_64-linux-gnu:$LIBRARY_PATH'
 set-env LD_LIBRARY_PATH '$HOME/.apt/usr/lib/x86_64-linux-gnu:$HOME/julia/lib:$HOME/julia/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH'
-set-env JULIA_LOAD_PATH '@:$HOME'
+set-env JULIA_LOAD_PATH '@:$HOME:'
 
 export LIBRARY_PATH=./.apt/usr/lib/x86_64-linux-gnu:./julia/lib:./julia/lib/x86_64-linux-gnu:$LIBRARY_PATH
 export LD_LIBRARY_PATH=./.apt/usr/lib/x86_64-linux-gnu:./julia/lib:./julia/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH

--- a/bin/detect
+++ b/bin/detect
@@ -6,6 +6,8 @@ if [ -f $1/Project.toml ]; then
   echo "Julia"
   exit 0
 else
-  echo "no Project.toml file"
-  exit 1
+  echo "Julia"
+  exit 0
+  # echo "no Project.toml file"
+  # exit 1
 fi


### PR DESCRIPTION
The default value for `precompile_statements_file` was `nothing`, which is [not of an allowed type](https://github.com/JuliaLang/PackageCompiler.jl/blob/2fba79c02664552c290aed7c946629cc86d77983/src/PackageCompiler.jl#L366). 

I suspect this happened because of a change in `PackageCompiler`, which was installed in `compile` without a fixed version number. The number is now fixed (to the recent `v1.1.1`) to prevent future issues like this :)